### PR TITLE
second attempt at directly navigating to main page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,8 +91,20 @@ function App(): JSX.Element {
                         ></TaskPage>
                     }
                 ></Route>
+                <Route
+                    path="/"
+                    element={
+                        <TaskPage
+                            role={role}
+                            setRole={setRole}
+                            roles={roles}
+                            setRoles={setRoles}
+                            tasks={tasks}
+                            setTasks={setTasks}
+                        ></TaskPage>
+                    }
+                ></Route>
                 <Route path="/homepage" element={<Navigate to="/taskpage" />} />
-                <Route path="/" element={taskPage}></Route>
             </Routes>
         </div>
     );


### PR DESCRIPTION
after deploying the original version, the default page was still only the header although it looked right on npm start. I changed the routing of the "/" path so it should reroute correctly to the taskpage now.