### PR TITLE
fixed issue with delete all finished tasks button

### DIFF
--- a/src/list-components/DisplayTask.tsx
+++ b/src/list-components/DisplayTask.tsx
@@ -37,6 +37,17 @@ export function DisplayTask(display: displayProps): JSX.Element {
         );
     }
 
+    //this function calls the component to display the status of the task
+    function CallEditStatus(): JSX.Element {
+        return (
+            <EditStatus
+                tasks={display.tasks}
+                updateTasks={display.updateTasks}
+                task={display.task}
+            ></EditStatus>
+        );
+    }
+
     return (
         <div
             ref={drag}
@@ -70,11 +81,7 @@ export function DisplayTask(display: displayProps): JSX.Element {
                     <br />
                     {display.task.description}
                     <br />
-                    <EditStatus
-                        tasks={display.tasks}
-                        updateTasks={display.updateTasks}
-                        task={display.task}
-                    ></EditStatus>
+                    <CallEditStatus></CallEditStatus>
                     <br />
                     Difficulty: {display.task.difficulty}
                     <br />

--- a/src/list-components/UserList.tsx
+++ b/src/list-components/UserList.tsx
@@ -263,10 +263,6 @@ export function UserList({
         return droppedTask ? true : false;
     }
 
-    function UserName(user: User) {
-        return String(user.name);
-    }
-
     if (user.name !== "Super" && user.name !== "Admin") {
         return (
             <div className="UserList">
@@ -360,7 +356,7 @@ export function UserList({
                                   task={TASK}
                                   tasks={user.userList}
                                   updateTasks={editUserList}
-                                  role={UserName(user)}
+                                  role={user.name}
                               ></DisplayTask>
                           ))
                         : null}
@@ -379,7 +375,7 @@ export function UserList({
                             task={TASK}
                             tasks={user.userList}
                             updateTasks={editUserList}
-                            role={UserName(user)}
+                            role={user.name}
                         ></DisplayTask>
                     ))}
                 </div>


### PR DESCRIPTION
When clicking the delete all finished tasks button, the remaining tasks render correctly now. Before some of them suddenly seemed to be done even though they weren't.